### PR TITLE
uxkb: add Compose (dead-key) support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ LT_INIT
 # Required pkg-config dependencies
 #
 
-PKG_CHECK_MODULES([XKBCOMMON], [xkbcommon])
+PKG_CHECK_MODULES([XKBCOMMON], [xkbcommon >= 0.5.0])
 AC_SUBST(XKBCOMMON_CFLAGS)
 AC_SUBST(XKBCOMMON_LIBS)
 

--- a/docs/man/kmscon.xml
+++ b/docs/man/kmscon.xml
@@ -290,6 +290,15 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--compose</option></term>
+        <listitem>
+                <para>Use Compose (dead-keys) support. See
+                      <citerefentry><refentrytitle>Compose</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                      for more details. (default: off)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--xkb-repeat-delay {delay}</option></term>
         <listitem>
           <para>Delay after key was pressed until key-repeat starts (in

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -110,6 +110,7 @@ static void print_help()
 		"\t                                 Initial delay for key-repeat in ms\n"
 		"\t    --xkb-repeat-rate <msecs>  [50]\n"
 		"\t                                 Delay between two key-repeats in ms\n"
+		"\t    --compose                  [off] Use Compose (dead-keys) support\n"
 		"\n"
 		"Grabs / Keyboard-Shortcuts:\n"
 		"\t    --grab-scroll-up <grab>     [<Shift>Up]\n"
@@ -578,6 +579,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_STRING(0, "xkb-keymap", &conf->xkb_keymap, ""),
 		CONF_OPTION_UINT(0, "xkb-repeat-delay", &conf->xkb_repeat_delay, 250),
 		CONF_OPTION_UINT(0, "xkb-repeat-rate", &conf->xkb_repeat_rate, 50),
+		CONF_OPTION_BOOL(0, "compose", &conf->compose, false),
 
 		/* Grabs / Keyboard-Shortcuts */
 		CONF_OPTION_GRAB(0, "grab-scroll-up", &conf->grab_scroll_up, &def_grab_scroll_up),

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -104,6 +104,8 @@ struct kmscon_conf_t {
 	char *xkb_options;
 	/* input predefined KBD keymap */
 	char *xkb_keymap;
+	/* use Compose/dead-keys support */
+	bool compose;
 	/* keyboard key-repeat delay */
 	unsigned int xkb_repeat_delay;
 	/* keyboard key-repeat rate */

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -715,6 +715,7 @@ int kmscon_seat_new(struct kmscon_seat **out,
 			      seat->conf->xkb_variant,
 			      seat->conf->xkb_options,
 			      keymap,
+			      seat->conf->compose,
 			      seat->conf->xkb_repeat_delay,
 			      seat->conf->xkb_repeat_rate,
 			      log_llog, NULL);

--- a/src/uterm_input.c
+++ b/src/uterm_input.c
@@ -226,6 +226,7 @@ int uterm_input_new(struct uterm_input **out,
 		    const char *variant,
 		    const char *options,
 		    const char *keymap,
+		    bool use_compose,
 		    unsigned int repeat_delay,
 		    unsigned int repeat_rate,
 		    uterm_input_log_t log,
@@ -262,7 +263,8 @@ int uterm_input_new(struct uterm_input **out,
 	if (ret)
 		goto err_free;
 
-	ret = uxkb_desc_init(input, model, layout, variant, options, keymap);
+	ret = uxkb_desc_init(input, model, layout, variant, options, keymap,
+				use_compose);
 	if (ret)
 		goto err_hook;
 

--- a/src/uterm_input.h
+++ b/src/uterm_input.h
@@ -80,7 +80,7 @@ typedef void (*uterm_input_cb) (struct uterm_input *input,
 
 int uterm_input_new(struct uterm_input **out, struct ev_eloop *eloop,
 		    const char *model, const char *layout, const char *variant,
-		    const char *options, const char *keymap,
+		    const char *options, const char *keymap, bool use_compose,
 		    unsigned int repeat_delay, unsigned int repeat_rate,
 		    uterm_input_log_t log, void *log_data);
 void uterm_input_ref(struct uterm_input *input);

--- a/src/uterm_input_internal.h
+++ b/src/uterm_input_internal.h
@@ -53,6 +53,7 @@ struct uterm_input_dev {
 	char *node;
 	struct ev_fd *fd;
 	struct xkb_state *state;
+	struct xkb_compose_state *compose_state;
 	/* Used in sleep/wake up to store the key's pressed/released state. */
 	char key_state_bits[SHL_DIV_ROUND_UP(KEY_CNT, CHAR_BIT)];
 
@@ -76,6 +77,7 @@ struct uterm_input {
 	struct shl_hook *hook;
 	struct xkb_context *ctx;
 	struct xkb_keymap *keymap;
+	struct xkb_compose_table *compose;
 
 	struct shl_dlist devices;
 };
@@ -90,7 +92,8 @@ int uxkb_desc_init(struct uterm_input *input,
 		   const char *layout,
 		   const char *variant,
 		   const char *options,
-		   const char *keymap);
+		   const char *keymap,
+		   bool compose);
 void uxkb_desc_destroy(struct uterm_input *input);
 
 int uxkb_dev_init(struct uterm_input_dev *dev);

--- a/tests/test_input.c
+++ b/tests/test_input.c
@@ -53,6 +53,7 @@ struct {
 	char *xkb_variant;
 	char *xkb_options;
 	char *xkb_keymap;
+	bool compose;
 } input_conf;
 
 /* Pressing Ctrl-\ should toggle the capturing. */
@@ -130,7 +131,7 @@ static void monitor_event(struct uterm_monitor *mon,
 				      input_conf.xkb_layout,
 				      input_conf.xkb_variant,
 				      input_conf.xkb_options,
-				      keymap,
+				      keymap, input_conf.compose,
 				      0, 0, log_llog, NULL);
 		if (ret)
 			return;
@@ -181,6 +182,7 @@ static void print_help()
 		"\t    --xkb-options <options> [-]     Set XkbOptions for input devices\n"
 		"\t    --xkb-keymap <FILE>     [-]     Use a predefined keymap for\n"
 		"\t                                    input devices\n",
+		"\t    --compose               [off]   Use Compose (dead-keys) support\n"
 		"test_input");
 	/*
 	 * 80 char line:
@@ -199,6 +201,7 @@ struct conf_option options[] = {
 	CONF_OPTION_STRING(0, "xkb-variant", &input_conf.xkb_variant, ""),
 	CONF_OPTION_STRING(0, "xkb-options", &input_conf.xkb_options, ""),
 	CONF_OPTION_STRING(0, "xkb-keymap", &input_conf.xkb_keymap, ""),
+	CONF_OPTION_BOOL(0, "compose", &input_conf.compose, false),
 };
 
 int main(int argc, char **argv)

--- a/tests/test_vt.c
+++ b/tests/test_vt.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
 	if (ret)
 		goto err_exit;
 
-	ret = uterm_input_new(&input, eloop, "", "", "", "", "", 0, 0,
+	ret = uterm_input_new(&input, eloop, "", "", "", "", "", false, 0, 0,
 			      log_llog, NULL);
 	if (ret)
 		goto err_vtm;


### PR DESCRIPTION
Dead keys are special keys which have no immediate effect when pressed,
but instead they modify the result of subsequent keys. For example,
pressing the <`> key (the dead key) and then <u> may produce the symbol
ú. Such sequences can be more elaborate and consist of several keysyms.

The compose mechanism has two main pieces of configuration:

1. The Compose file, which defines the compose sequences. It is picked
   by the user's locale. See the Compose(5) man page; most of it is
   supported. These files are currently a part of libX11, but some users
   write their own. For example:
   /usr/share/X11/locale/en_US.UTF-8/Compose

2. The user's XKB keymap, which defines which keys are dead keys (that
   is, produce keysyms of the form dead_*, which are normally used in
   Compose sequences) and which key is the Compose key (which starts
   many Compose sequences). For example, the us 'intl' variant.

A new --compose command-line option is added, and is off by default.
In any case, if the initialization fails, there is simply no Compose
support, it is non-fatal.

Here is an example configuration which uses dead keys:
    kmscon --compose --xkb-layout=us --xkb-variant=intl --xkb-options=ralt:compose

This feature (and more) is usually provided by an input method. But we
use the lightweight support provided by xkbcommon.

Signed-off-by: Ran Benita <ran234@gmail.com>